### PR TITLE
Clean astar_2d_planner and add timing logs

### DIFF
--- a/astar_2d_planner/CMakeLists.txt
+++ b/astar_2d_planner/CMakeLists.txt
@@ -6,30 +6,20 @@ find_package(mbf_octo_core REQUIRED)
 find_package(mbf_msgs REQUIRED)
 find_package(mbf_utility REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(rclcpp_action REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(pcl_conversions REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
-find_package(std_srvs REQUIRED)
 find_package(nav_msgs REQUIRED)  # ExePath goal.path
 find_package(geometry_msgs REQUIRED)
-find_package(rosidl_default_generators REQUIRED) # For StartNav.srv
 
 pluginlib_export_plugin_description_file(mbf_octo_core astar_2d_planner.xml)
 
-rosidl_generate_interfaces(${PROJECT_NAME}
-  "srv/StartNav.srv"
-)
-
-# Export rosidl
-ament_export_dependencies(rosidl_default_runtime)
-
-# Define using core library as <project>_core
-add_library(${PROJECT_NAME}_core SHARED
+# Define library
+add_library(${PROJECT_NAME} SHARED
   src/astar_2d_planner.cpp
 )
-ament_target_dependencies(${PROJECT_NAME}_core
+ament_target_dependencies(${PROJECT_NAME}
   rclcpp 
   mbf_octo_core 
   mbf_msgs 
@@ -42,50 +32,28 @@ ament_target_dependencies(${PROJECT_NAME}_core
   tf2_geometry_msgs
 )
 
-target_include_directories(${PROJECT_NAME}_core PUBLIC
+target_include_directories(${PROJECT_NAME} PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:include>
   ${pluginlib_INCLUDE_DIRS}
 )
-target_compile_definitions(${PROJECT_NAME}_core PRIVATE 
+target_compile_definitions(${PROJECT_NAME} PRIVATE
   "astar_2d_planner_BUILDING_LIBRARY"
 )
 
-target_link_libraries(${PROJECT_NAME}_core
+target_link_libraries(${PROJECT_NAME}
   ${MPI_CXX_LIBRARIES}
 )
 
 # Define for exe_path_after_node
-add_executable(exe_path_after_node 
-  src/exe_path_node.cpp
-)
-
-ament_target_dependencies(exe_path_after_node
-  rclcpp 
-  rclcpp_action
-  std_srvs 
-  nav_msgs 
-  mbf_msgs 
-  mbf_octo_core
-  mbf_utility
-  geometry_msgs
-)
-
-# Two path
-# ROSIDL typesupport to exe
-# rosidl_target_interfaces(exe_path_after_node "rosidl_typesupport_cpp")
-rosidl_get_typesupport_target(TYPESUPPORT_CPP_TARGET ${PROJECT_NAME} "rosidl_typesupport_cpp")
-target_link_libraries(exe_path_after_node ${TYPESUPPORT_CPP_TARGET})
-
 # install rule
 install(
   TARGETS
-    ${PROJECT_NAME}_core
-    exe_path_after_node
+    ${PROJECT_NAME}
   EXPORT export_${PROJECT_NAME}
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  RUNTIME DESTINATION lib/${PROJECT_NAME}
+  RUNTIME DESTINATION lib
 )
 
 install(
@@ -108,15 +76,14 @@ install(
 
 # export for ament
 ament_export_include_directories(include)
-ament_export_libraries(${PROJECT_NAME}_core)
+ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(export_${PROJECT_NAME})
 ament_export_dependencies(
-  mbf_octo_core 
-  mbf_msgs 
-  mbf_utility 
-  rclcpp 
+  mbf_octo_core
+  mbf_msgs
+  mbf_utility
+  rclcpp
   pluginlib
-  std_srvs
   nav_msgs
   geometry_msgs
   )

--- a/astar_2d_planner/include/astar_2d_planner/astar_2d_planner.h
+++ b/astar_2d_planner/include/astar_2d_planner/astar_2d_planner.h
@@ -210,10 +210,6 @@ private:
       astar(const std::pair<int,int>& start,
             const std::pair<int,int>& goal);
   void mapCallback(const nav_msgs::msg::OccupancyGrid::SharedPtr msg);
-  void goalPoseCallback(const geometry_msgs::msg::PoseStamped::SharedPtr msg);
-  rclcpp::Subscription<geometry_msgs::msg::PoseStamped>::SharedPtr goal_sub_;
-  rclcpp_action::Client<mbf_msgs::action::MoveBase>::SharedPtr      mbf_client_;
-  rclcpp_action::Client<mbf_msgs::action::GetPath>::SharedPtr      mbf_getpath_client_;
   
   // Utility functions of the 3D Planner.
   // // Callback for point cloud subscription.

--- a/astar_2d_planner/package.xml
+++ b/astar_2d_planner/package.xml
@@ -8,18 +8,13 @@
   <license>Apache-2.0</license>
 
   <depend>rclcpp</depend>
-  <depend>rclcpp_action</depend>
   <depend>pluginlib</depend>
-  <depend>std_srvs</depend>
   <depend>nav_msgs</depend>
   <depend>mbf_msgs</depend>
   <depend>mbf_octo_core</depend>
   <depend>mbf_utility</depend>
   <depend>geometry_msgs</depend>
 
-  <member_of_group>rosidl_interface_packages</member_of_group>
-  <depend>rosidl_default_generators</depend>
-  <depend>rosidl_default_runtime</depend>
 
   <export>
     <build_type>ament_cmake</build_type>


### PR DESCRIPTION
- remove unused StartNav references and old exe target
- rename the planner library to `astar_2d_planner`
- drop obsolete dependencies
- cleanup unused fields in the planner header
- log planning and smoothing timings